### PR TITLE
Re-use the serial monitor Terminal window

### DIFF
--- a/plugin/vim-arduino-serial
+++ b/plugin/vim-arduino-serial
@@ -5,14 +5,37 @@ echo "use Ctrl-a, k to exit the screen utility"
 port=$(ls /dev/tty.* | grep usb)
 
 osascript -e \
-  "tell application \"iTerm\"
-    activate
-    set myterm to (current terminal)
-    tell myterm
-      set mysession to (make new session at the end of sessions)
-      tell mysession
-        exec command \"/bin/bash -l\"
-        write text \"screen $port\"
-      end tell
+  "tell application \"Terminal\"
+  activate
+
+  -- search all windows for the arduino-serial tab
+  set winlist to every window
+  local arduinoTab
+  repeat with win in winlist
+    set tablist to every tab of win
+    repeat with currentTab in tablist
+      set title to get custom title of currentTab
+      if title is equal to \"arduino-serial\" then
+        set arduinoTab to currentTab
+        set frontmost of win to true
+      end if
+    end repeat
+  end repeat
+
+  -- make new tab when arduino-serial does not exist
+  try
+    arduinoTab
+  on error
+    tell application \"System Events\"
+      set frontmost of application process \"Terminal\" to true
+      keystroke \"t\" using command down
     end tell
-   end tell"
+    set currentTabIndex to (get count of tabs of front window)
+    set arduinoTab to (tab currentTabIndex of front window)
+    set custom title of arduinoTab to \"arduino-serial\"
+  end try
+
+  tell front window
+    do script \"screen -S arduino-serial $port\" in arduinoTab
+  end tell
+end tell"

--- a/plugin/vim-arduino.vim
+++ b/plugin/vim-arduino.vim
@@ -24,6 +24,7 @@ endfunction
 "
 " Returns nothing.
 function! s:InvokeArduinoCli(deploy)
+  call s:ArduinoKillMonitor()
   let l:flag = a:deploy ? "-d" : "-c"
   let l:f_name = expand('%:p')
   execute "w"
@@ -39,6 +40,13 @@ function! s:InvokeArduinoCli(deploy)
   call s:PrintStatus(v:shell_error)
 
   return !v:shell_error
+endfunction
+
+" Private: Release the /dev/tty.usb* port so we can recompile
+"
+" Returns nothing.
+function! s:ArduinoKillMonitor()
+  let output = system("screen -X -S arduino-serial quit")
 endfunction
 
 " Public: Compile the current pde file.
@@ -64,9 +72,8 @@ endfunction
 "
 " Returns nothing.
 function! ArduinoSerialMonitor()
-  if ArduinoDeploy()
-    echo system(s:helper_dir."/vim-arduino-serial")
-  endif
+  call s:ArduinoKillMonitor()
+  echo system(s:helper_dir."/vim-arduino-serial")
 endfunction
 
 if !exists('g:vim_arduino_map_keys')


### PR DESCRIPTION
* ArduinoSerialMonitor no longer deploys the code, it simply launches
 the serial monitor. This allows you to launch the monitor after
 deploying without re-deploying. It also fixes a recursion bug if you
 have auto_open_serial set.
* The screen session is named. This allows us to kill the session before
 each deploy, allowing you to deploy without manually stopping the
 serial monitor
* The AppleScript uses the native Terminal application, removing the
 iTerm dependency.
* The AppleScript uses the same Terminal window for serial monitoring.
 If a serial monitor tab doesn't exist it creates one.

 Basically, this commit allows you to open the serial monitor at will,
 and decouples serial monitor management from deployment. You can
 `<leader>ad` at will and the monitor will always be up to date.