### PR TITLE
Allow users to use custom build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ add this to your `.vimrc`:
 let g:vim_arduino_auto_open_serial = 1
 ```
 
+To change the command used to build and deploy :
+
+```
+let g:vim_arduino_ino_cmd = 'ano'
+```
+
 
 [ino-config]: http://inotool.org/quickstart#configuration-files
 [ino-source]: https://pypi.python.org/pypi/ino/#downloads

--- a/plugin/vim-arduino.vim
+++ b/plugin/vim-arduino.vim
@@ -10,6 +10,10 @@ if !exists('g:vim_arduino_auto_open_serial')
   let g:vim_arduino_auto_open_serial = 0
 endif
 
+if !exists('g:vim_arduino_ino_cmd')
+  let g:vim_arduino_ino_cmd = 'ino'
+endif
+
 let s:helper_dir = expand("<sfile>:h")
 
 function! s:PrintStatus(result)
@@ -29,10 +33,10 @@ function! s:InvokeArduinoCli(deploy)
   execute "w"
   if a:deploy
     echomsg "Compiling and deploying..." l:f_name
-    let l:result = system("ino build && ino upload")
+    let l:result = system(g:vim_arduino_ino_cmd . " build && " . g:vim_arduino_ino_cmd . " upload")
   else
     echomsg "Compiling..." l:f_name
-    let l:result = system("ino build")
+    let l:result = system(g:vim_arduino_ino_cmd . " build")
   endif
 
   echo l:result


### PR DESCRIPTION
The `ino` tool is no longer under active development. There is a fork named [Arturo](https://github.com/scottdarch/Arturo/) maintained, but it uses `ano` as the command name. This change simply allows users to specify a custom command to run instead of assuming `ino`.